### PR TITLE
Fix incompatibilities with current TYPO3 versions

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1253,7 +1253,9 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
             }
             $moreResults = $this->getListObjects($identifier, $overrideArgs);
             $result['Contents'] = array_merge($result['Contents'], $moreResults['Contents']);
-            $result['CommonPrefixes'] = array_merge($result['CommonPrefixes'], $moreResults['CommonPrefixes']);
+            if (!empty($result['CommonPrefixes']) && !empty($moreResults['CommonPrefixes'])) {
+                $result['CommonPrefixes'] = array_merge($result['CommonPrefixes'], $moreResults['CommonPrefixes']);
+            }
         }
         return $result;
     }

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -8,6 +8,7 @@ use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Resource\Folder;
+use TYPO3\CMS\Core\Resource\ResourceStorageInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Core\Resource\Driver\AbstractHierarchicalFilesystemDriver;
@@ -141,7 +142,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
      */
     public static function loadExternalClasses()
     {
-        if ((!GeneralUtility::compat_version('7.6.0') || !Bootstrap::usesComposerClassLoading()) && !function_exists('Aws\manifest')) {
+        if ((!GeneralUtility::compat_version('7.6.0') || !Bootstrap::usesComposerClassLoading()) && !function_exists('Aws\\manifest')) {
             require_once(GeneralUtility::getFileAbsFileName('EXT:' . self::EXTENSION_KEY . '/Resources/Private/PHP/Aws/aws-autoloader.php'));
         }
     }
@@ -973,7 +974,6 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
                 'TYPO3\CMS\Core\Messaging\FlashMessage',
                 LocalizationUtility::translate($localizationPrefix . 'connectionTestSuccessful.message', static::EXTENSION_NAME),
                 LocalizationUtility::translate($localizationPrefix . 'connectionTestSuccessful.title', static::EXTENSION_NAME),
-                '',
                 FlashMessage::OK
             );
             $messageQueue->addMessage($message);
@@ -1028,6 +1028,12 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
     protected function getObjectPermissions($identifier)
     {
         $this->normalizeIdentifier($identifier);
+        if ($identifier === '') {
+            $identifier = self::ROOT_FOLDER_IDENTIFIER;
+        }
+        if ($identifier === ResourceStorageInterface::DEFAULT_ProcessingFolder) {
+            $identifier = rtrim($identifier, '/') . '/';
+        }
         if (!isset($this->objectPermissionsCache[$identifier])) {
             if ($identifier === self::ROOT_FOLDER_IDENTIFIER) {
                 $permissions = array('r' => true, 'w' => true,);

--- a/Resources/Private/PHP/Aws/aws-autoloader.php
+++ b/Resources/Private/PHP/Aws/aws-autoloader.php
@@ -518,7 +518,13 @@ spl_autoload_register(function ($class) use ($mapping) {
 }, true);
 
 require __DIR__ . '/Aws/functions.php';
-require __DIR__ . '/GuzzleHttp/functions.php';
-require __DIR__ . '/GuzzleHttp/Psr7/functions.php';
-require __DIR__ . '/GuzzleHttp/Promise/functions.php';
+if (!function_exists('GuzzleHttp\\uri_template')) {
+    require __DIR__ . '/GuzzleHttp/functions.php';
+}
+if (!function_exists('GuzzleHttp\\Psr7\\str')) {
+    require __DIR__ . '/GuzzleHttp/Psr7/functions.php';
+}
+if (!function_exists('GuzzleHttp\\Promise\\queue')) {
+    require __DIR__ . '/GuzzleHttp/Promise/functions.php';
+}
 require __DIR__ . '/JmesPath/JmesPath.php';

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   },
   "license": "GPL-2.0+",
   "require": {
-    "typo3/cms": "*",
+    "typo3/cms-core": "^6.2 || ^7.6 || ^8.0",
     "aws/aws-sdk-php": "^3.20"
   },
   "autoload": {
@@ -20,6 +20,7 @@
     }
   },
   "replace": {
+    "aus_driver_amazon_s3": "self.version",
     "typo3-ter/aus_driver_amazon_s3": "self.version",
     "typo3-ter/aus-driver-amazon-s3": "self.version"
   }


### PR DESCRIPTION
* Assume root folder for emtpy identifier
* Enforce trailing slash for processing folder
* Fix autoloading fatal error in non composer mode