### PR TITLE
[BUGFIX] use the parameter in getFileInfoByIdentifier() 

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -233,7 +233,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
         $lastModified = $metadata['LastModified'];
         $lastModifiedUnixTimestamp = $lastModified->getTimestamp();
 
-        return array(
+        $return = array(
             'name' => basename($fileIdentifier),
             'identifier' => $fileIdentifier,
             'ctime' => $lastModifiedUnixTimestamp,
@@ -244,6 +244,12 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
             'folder_hash' => $this->hashIdentifier(PathUtility::dirname($fileIdentifier)),
             'storage' => $this->storageUid
         );
+
+        if (count($propertiesToExtract) > 0) {
+            $return = array_intersect_key($return, array_flip($propertiesToExtract));
+        }
+
+        return $return;
     }
 
     /**


### PR DESCRIPTION
in `AmazonS3Driver->getFileInfoByIdentifier()`
the parameter `$propertiesToExtract` was ignored. That led
`typo3/sysext/core/Classes/Resource/AbstractFile.php getSize()`
to always return the storageUid instead of the correct size.

