### PR TITLE
[TASK] implement dumpFileContents() to allow forceDownload

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -845,12 +845,12 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
      *
      * @param string $identifier
      * @return void
-     * @throws \TYPO3\CMS\Extbase\Persistence\Generic\Exception\NotImplementedException
-     * @toDo: Implement
      */
     public function dumpFileContents($identifier)
     {
-        throw new \TYPO3\CMS\Extbase\Persistence\Generic\Exception\NotImplementedException(__METHOD__);
+        $fileContents = $this->getFileContents($identifier);
+        echo $fileContents;
+        exit;
     }
 
     /**


### PR DESCRIPTION
adds a very basic implementation to allow forceDownload and for example the use of fal_securedownload