### PR TITLE
[BUGFIX] Register the driver via $GLOBALS

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,14 +3,12 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
-/** @var \TYPO3\CMS\Core\Resource\Driver\DriverRegistry $driverRegistry */
-$driverRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\Driver\DriverRegistry::class);
-$driverRegistry->registerDriverClass(
-    \AUS\AusDriverAmazonS3\Driver\AmazonS3Driver::class,
-    \AUS\AusDriverAmazonS3\Driver\AmazonS3Driver::DRIVER_TYPE,
-    'Amazon S3',
-    'FILE:EXT:' . \AUS\AusDriverAmazonS3\Driver\AmazonS3Driver::EXTENSION_KEY . '/Configuration/FlexForm/AmazonS3DriverFlexForm.xml'
-);
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['registeredDrivers'][\AUS\AusDriverAmazonS3\Driver\AmazonS3Driver::DRIVER_TYPE] = [
+    'class' => \AUS\AusDriverAmazonS3\Driver\AmazonS3Driver::class,
+    'flexFormDS' => 'FILE:EXT:' . \AUS\AusDriverAmazonS3\Driver\AmazonS3Driver::EXTENSION_KEY . '/Configuration/FlexForm/AmazonS3DriverFlexForm.xml',
+    'label' => 'Amazon S3',
+    'shortName' => \AUS\AusDriverAmazonS3\Driver\AmazonS3Driver::DRIVER_TYPE,
+];
 
 // register extractor
 \TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::getInstance()->registerExtractionService(\AUS\AusDriverAmazonS3\Index\Extractor::class);


### PR DESCRIPTION
TYPO3 extensions must not use the DriverRegistry to register
their driver implementations. See the TYPO3 coredev channel message
https://typo3.slack.com/archives/C03AM9R17/p1538658116000100
for more information.