### PR TITLE
[BUGFIX] Using headObject to proof that a folder exists does not work in every case

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -313,7 +313,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
         if (substr($identifier, -1) !== '/') {
             $identifier .= '/';
         }
-        return $this->objectExists($identifier);
+        return $this->prefixExists($identifier);
     }
 
     /**
@@ -335,7 +335,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
      */
     public function folderExistsInFolder($folderName, $folderIdentifier)
     {
-        return $this->objectExists($folderIdentifier . $folderName . '/');
+        return $this->prefixExists($folderIdentifier . $folderName . '/');
     }
 
     /**
@@ -1112,6 +1112,21 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
     protected function objectExists($identifier)
     {
         return $this->getMetaInfo($identifier) !== null;
+    }
+
+    /**
+     * Checks if a prefix exists
+     *
+     * @param string $identifier
+     * @return bool
+     */
+    protected function prefixExists($identifier)
+    {
+        if($this->objectExists($identifier)){
+            return true;
+        }
+        $objects = $this->getListObjects($identifier);
+        return count($objects) > 0;
     }
 
     /**


### PR DESCRIPTION
If files in the bucket were created by a 3rd party tool and the folder structure is not created explicity beforehand (which is not necesssary because S3 allows a structured filesystem just by prefixes), the headObject method returns a 404, because there is no folder object to fetch meta data from. 

We can use listObjects in this case. If it delivers min. 1 object, we can assume that it is a folder.