### PR TITLE
Use listObjectsV2 instead of headObject for checking if a folder exists

### DIFF
--- a/Classes/Index/Extractor.php
+++ b/Classes/Index/Extractor.php
@@ -1,5 +1,4 @@
 <?php
-namespace AUS\AusDriverAmazonS3\Index;
 
 /***
  *
@@ -12,6 +11,8 @@ namespace AUS\AusDriverAmazonS3\Index;
  * Stefan Lamm <s.lamm@andersundsehr.com>, anders und sehr GmbH
  *
  ***/
+
+namespace AUS\AusDriverAmazonS3\Index;
 
 use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use TYPO3\CMS\Core\Resource\File;

--- a/Classes/S3Adapter/AbstractS3Adapter.php
+++ b/Classes/S3Adapter/AbstractS3Adapter.php
@@ -1,5 +1,4 @@
 <?php
-namespace AUS\AusDriverAmazonS3\S3Adapter;
 
 /***
  *
@@ -11,6 +10,8 @@ namespace AUS\AusDriverAmazonS3\S3Adapter;
  * (c) 2019 Markus Hölzle <typo3@markus-hoelzle.de>
  *
  ***/
+
+namespace AUS\AusDriverAmazonS3\S3Adapter;
 
 use Aws\S3\S3Client;
 

--- a/Classes/S3Adapter/MetaInfoDownloadAdapter.php
+++ b/Classes/S3Adapter/MetaInfoDownloadAdapter.php
@@ -1,5 +1,4 @@
 <?php
-namespace AUS\AusDriverAmazonS3\S3Adapter;
 
 /***
  *
@@ -11,6 +10,8 @@ namespace AUS\AusDriverAmazonS3\S3Adapter;
  * (c) 2019 Markus Hölzle <typo3@markus-hoelzle.de>
  *
  ***/
+
+namespace AUS\AusDriverAmazonS3\S3Adapter;
 
 use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Classes/S3Adapter/MultipartUploaderAdapter.php
+++ b/Classes/S3Adapter/MultipartUploaderAdapter.php
@@ -1,5 +1,4 @@
 <?php
-namespace AUS\AusDriverAmazonS3\S3Adapter;
 
 /***
  *
@@ -11,6 +10,8 @@ namespace AUS\AusDriverAmazonS3\S3Adapter;
  * (c) 2019 Markus Hölzle <typo3@markus-hoelzle.de>
  *
  ***/
+
+namespace AUS\AusDriverAmazonS3\S3Adapter;
 
 use Aws\Exception\MultipartUploadException;
 use Aws\S3\MultipartUploader;

--- a/Classes/Signal/FileIndexRepository.php
+++ b/Classes/Signal/FileIndexRepository.php
@@ -1,5 +1,4 @@
 <?php
-namespace AUS\AusDriverAmazonS3\Signal;
 
 /***
  *
@@ -12,6 +11,8 @@ namespace AUS\AusDriverAmazonS3\Signal;
  * Stefan Lamm <s.lamm@andersundsehr.com>, anders und sehr GmbH
  *
  ***/
+
+namespace AUS\AusDriverAmazonS3\Signal;
 
 use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use AUS\AusDriverAmazonS3\Index\Extractor;

--- a/Tests/Unit/Driver/AmazonS3DriverTest.php
+++ b/Tests/Unit/Driver/AmazonS3DriverTest.php
@@ -1,5 +1,4 @@
 <?php
-namespace AUS\AusDriverAmazonS3\Tests\Unit\Driver;
 
 /***
  *
@@ -11,6 +10,8 @@ namespace AUS\AusDriverAmazonS3\Tests\Unit\Driver;
  * (c) 2019 Markus Hölzle <typo3@markus-hoelzle.de>
  *
  ***/
+
+namespace AUS\AusDriverAmazonS3\Tests\Unit\Driver;
 
 use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use Aws\Api\DateTimeResult;

--- a/Tests/Unit/Index/ExtractorTest.php
+++ b/Tests/Unit/Index/ExtractorTest.php
@@ -1,5 +1,4 @@
 <?php
-namespace AUS\AusDriverAmazonS3\Tests\Unit\Index;
 
 /***
  *
@@ -11,6 +10,8 @@ namespace AUS\AusDriverAmazonS3\Tests\Unit\Index;
  * (c) 2019 Markus Hölzle <typo3@markus-hoelzle.de>
  *
  ***/
+
+namespace AUS\AusDriverAmazonS3\Tests\Unit\Index;
 
 use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use AUS\AusDriverAmazonS3\Index\Extractor;

--- a/Tests/Unit/S3Adapter/MetaInfoDownloadAdapterTest.php
+++ b/Tests/Unit/S3Adapter/MetaInfoDownloadAdapterTest.php
@@ -1,5 +1,4 @@
 <?php
-namespace AUS\AusDriverAmazonS3\Tests\Unit\S3Adapter;
 
 /***
  *
@@ -11,6 +10,8 @@ namespace AUS\AusDriverAmazonS3\Tests\Unit\S3Adapter;
  * (c) 2019 Markus Hölzle <typo3@markus-hoelzle.de>
  *
  ***/
+
+namespace AUS\AusDriverAmazonS3\Tests\Unit\S3Adapter;
 
 use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use AUS\AusDriverAmazonS3\S3Adapter\MetaInfoDownloadAdapter;

--- a/Tests/Unit/Signal/FileIndexRepositoryTest.php
+++ b/Tests/Unit/Signal/FileIndexRepositoryTest.php
@@ -1,5 +1,4 @@
 <?php
-namespace AUS\AusDriverAmazonS3\Tests\Unit\Signal;
 
 /***
  *
@@ -11,6 +10,8 @@ namespace AUS\AusDriverAmazonS3\Tests\Unit\Signal;
  * (c) 2019 Markus Hölzle <typo3@markus-hoelzle.de>
  *
  ***/
+
+namespace AUS\AusDriverAmazonS3\Tests\Unit\Signal;
 
 use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use AUS\AusDriverAmazonS3\Index\Extractor;


### PR DESCRIPTION
headObject() doesn't work for me on prefixes created using AWS CLI's S3
sync feature. It returns a 404 Not Found. I have no idea why, but
listObjectsV2 with a prefix does work.

I also had to fix some code style issues because a pre-commit hook
wouldn't let me commit otherwise.