### PR TITLE
MultipartUploader fails to upload empty files

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -397,13 +397,21 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
         } else { // upload local file
             $this->normalizeIdentifier($targetIdentifier);
 
-            $multipartUploadAdapter = GeneralUtility::makeInstance(MultipartUploaderAdapter::class, $this->s3Client);
-            $multipartUploadAdapter->upload(
-                $localFilePath,
-                $targetIdentifier,
-                $this->configuration['bucket'],
-                $this->getCacheControl($targetIdentifier)
-            );
+            if (filesize($localFilePath) === 0) { // Multipart uploader would fail to upload empty files
+                $this->s3Client->upload(
+                    $this->configuration['bucket'],
+                    $targetIdentifier,
+                    ''
+                );
+            } else {
+                $multipartUploadAdapter = GeneralUtility::makeInstance(MultipartUploaderAdapter::class, $this->s3Client);
+                $multipartUploadAdapter->upload(
+                    $localFilePath,
+                    $targetIdentifier,
+                    $this->configuration['bucket'],
+                    $this->getCacheControl($targetIdentifier)
+                );
+            }
 
             if ($removeOriginal) {
                 unlink($localFilePath);


### PR DESCRIPTION
Empty files cannot be created with MultpartUploader.
Also, when an error occurs in the MultipartUploader, the MultipartUploadAdapter will retry the upload forever. This might be useful for temporary errors like Network problems, but blocks a PHP process and creates high server load for permanent errors (like the one with the empty files)

This patch
- Fixes the upload error by creating the file directly instead
- Introduces a retry limit and aborts the upload if too many errors occur

I'm not sure if MAX_RETRIES = 10 is appropriate, but in my tests I didn't need a single retry even when uploading big files.