### PR TITLE
Support MinIO storage backend

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -344,7 +344,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
      */
     public function folderExistsInFolder($folderName, $folderIdentifier)
     {
-        return $this->prefixExists($folderIdentifier . $folderName . '/');
+        return $this->prefixExists(rtrim($folderIdentifier, '/') . '/' . $folderName . '/');
     }
 
     /**

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1112,6 +1112,12 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
         if (!empty($this->configuration['signature'])) {
             $configuration['signature_version'] = $this->configuration['signature_version'];
         }
+        if (!empty($this->configuration['customHost'])) {
+            $configuration['endpoint'] = $this->configuration['customHost'];
+        }
+        if (!empty($this->configuration['pathStyleEndpoint'])) {
+            $configuration['use_path_style_endpoint'] = true;
+        }
 
         if (
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][self::EXTENSION_KEY]['initializeClient-preProcessing']) &&

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1349,7 +1349,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
      * @param string $body
      * @param array $overrideArgs
      */
-    protected function createObject($identifier, $body = ' ', $overrideArgs = [])
+    protected function createObject($identifier, $body = '', $overrideArgs = [])
     {
         $this->normalizeIdentifier($identifier);
         $args = [

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -483,7 +483,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
     {
         if ($deleteRecursively) {
             $items = $this->getListObjects($folderIdentifier);
-            foreach ($items['Contents'] as $object) {
+            foreach ($items['Contents'] ?? [] as $object) {
                 // Filter the folder itself
                 if ($object['Key'] !== $folderIdentifier) {
                     if ($this->isDir($object['Key'])) {
@@ -747,7 +747,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
         );
 
         // Contents will always include the folder itself
-        if (sizeof($result['Contents']) > 1) {
+        if (isset($result['Contents']) && sizeof($result['Contents']) > 1) {
             return false;
         }
         return true;

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1513,6 +1513,10 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
             }
         }
 
+        if (isset($overrideArgs['MaxKeys']) && $overrideArgs['MaxKeys'] <= 1000) {
+            return $result;
+        }
+
         // Amazon S3 lists max 1000 files, so we have to get all recursive
         if ($result['IsTruncated']) {
             $overrideArgs['ContinuationToken'] = $result['NextContinuationToken'];

--- a/Configuration/FlexForm/AmazonS3DriverFlexForm.xml
+++ b/Configuration/FlexForm/AmazonS3DriverFlexForm.xml
@@ -117,6 +117,27 @@
 					</config>
 				</TCEforms>
 			</region>
+			<customHost>
+				<TCEforms>
+					<label>LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.customHost</label>
+					<description>LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.customHost-description</description>
+					<config>
+						<type>input</type>
+						<renderType>inputLink</renderType>
+						<size>30</size>
+					</config>
+				</TCEforms>
+			</customHost>
+			<pathStyleEndpoint>
+				<TCEforms>
+					<label>LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.pathStyleEndpoint</label>
+					<description>LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.pathStyleEndpoint-description</description>
+					<config>
+						<type>check</type>
+						<default>0</default>
+					</config>
+				</TCEforms>
+			</pathStyleEndpoint>
 			<key>
 				<TCEforms>
 					<label>LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.key</label>

--- a/Configuration/FlexForm/AmazonS3DriverFlexForm.xml
+++ b/Configuration/FlexForm/AmazonS3DriverFlexForm.xml
@@ -160,6 +160,7 @@
 			<publicBaseUrl>
 				<TCEforms>
 					<label>LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.publicBaseUrl</label>
+					<description>LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.publicBaseUrl-description</description>
 					<config>
 						<type>input</type>
 						<size>30</size>

--- a/Resources/Private/Language/locallang_flexform.xlf
+++ b/Resources/Private/Language/locallang_flexform.xlf
@@ -9,6 +9,18 @@
 			<trans-unit id="driverConfiguration.bucket">
 				<source>AWS S3: Bucket</source>
 			</trans-unit>
+			<trans-unit id="driverConfiguration.customHost">
+				<source>Custom host name</source>
+			</trans-unit>
+			<trans-unit id="driverConfiguration.customHost-description">
+				<source>For S3-compatible services like MinIO. "Region" is ignored if this is filled.</source>
+			</trans-unit>
+			<trans-unit id="driverConfiguration.pathStyleEndpoint">
+				<source>Use path-style endpoint</source>
+			</trans-unit>
+			<trans-unit id="driverConfiguration.pathStyleEndpoint-description">
+				<source>Put the bucket in the URL path and not the domain. Example: "http://s3.amazonaws.com/bucket" instead of "http://bucket.s3.amazonaws.com".</source>
+			</trans-unit>
 			<trans-unit id="driverConfiguration.key">
 				<source>AWS S3: Key</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_flexform.xlf
+++ b/Resources/Private/Language/locallang_flexform.xlf
@@ -30,6 +30,9 @@
 			<trans-unit id="driverConfiguration.publicBaseUrl">
 				<source>AWS S3: Public base URL (optional)</source>
 			</trans-unit>
+			<trans-unit id="driverConfiguration.publicBaseUrl-description">
+				<source>Without protocol - "Protocol" setting is used here.</source>
+			</trans-unit>
 			<trans-unit id="driverConfiguration.cacheHeaderDuration">
 				<source>Cache header: max age (in seconds, optional)</source>
 			</trans-unit>


### PR DESCRIPTION
These patches add support for S3-compatible storage services like https://min.io/ and fix a bug when creating folders on a minio backend ("XMinioObjectExistsAsDirectory / Object name already exists as a directory.").
It also adds a description for the public base URL field so people see that the protocol may not be entered there.

Resolves: https://github.com/andersundsehr/aus_driver_amazon_s3/issues/62

It includes the commit for pull request #83, because performance is abysmal without it.

# Example configuration settings for a local minio instance
Given that minio is running on port 9000 and that the bucket is publicly accessible (`mc policy set download minio/typo3`)

- bucket: typo3
- region: any (will be ignored)
- customHost: http://minio:9000
- pathStyleEndpoint: true
- key: your read-write access key
- secretKey: your read-write password
- publicBaseUrl: minio:9000/typo3/
- protocol: auto
- signature: auto

# Screenshots
![2021-05-14 srh typo3 s3 preview](https://user-images.githubusercontent.com/59036/118270809-cd899b00-b4c0-11eb-9ae5-330b9f62d9f4.png)
![2021-05-14 typo3 s3 minio valid](https://user-images.githubusercontent.com/59036/118270816-cfebf500-b4c0-11eb-9f58-a56467907b50.png)
