### PR TITLE
[BUGFIX] Throw \InvalidArgumentException when a file does not exist.

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -282,7 +282,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      * @param array $propertiesToExtract Array of properties which are be extracted
      *                                    If empty all will be extracted
      * @return array
-     * @throws \Exception
+     * @throws \InvalidArgumentException If the file does not exist
      */
     public function getFileInfoByIdentifier($fileIdentifier, array $propertiesToExtract = [])
     {
@@ -292,7 +292,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
         }
         $return = $this->getMetaInfo($fileIdentifier);
         if ($return === null) {
-            throw new \Exception('File does not exist', 1503500470);
+            throw new \InvalidArgumentException('File ' . $fileIdentifier . ' does not exist', 1503500470);
         }
         if (count($propertiesToExtract) > 0) {
             $return = array_intersect_key($return, array_flip($propertiesToExtract));


### PR DESCRIPTION
.. instead of throwing a generic \Exception.

\TYPO3\CMS\Core\Resource\Driver\LocalDriver (TYPO3 v10.4) already
throws that exception class when a file does not exist.
Other extensions like VHS depend on that behavior, because they catch
those exceptions to specifically handle the file-not-found case.

Also mention the name of the missing file in the exception message
to ease debugging.

Related: https://github.com/FluidTYPO3/vhs/issues/1725