### PR TITLE
[BUGFIX] Respect "MaxKeys" setting when listing objects

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1513,6 +1513,10 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver
             }
         }
 
+        if (isset($overrideArgs['MaxKeys']) && $overrideArgs['MaxKeys'] <= 1000) {
+            return $result;
+        }
+
         // Amazon S3 lists max 1000 files, so we have to get all recursive
         if ($result['IsTruncated']) {
             $overrideArgs['ContinuationToken'] = $result['NextContinuationToken'];


### PR DESCRIPTION
Methods prefixExists() and isFolderEmpty() both use getListObjects()
with the "MaxKeys: 1" argument.
If the directory contains more than one file, the API says the result is
truncated (which we wanted!), which causes getListObjects() to load all
objects in the folder.

This patch checks if the MaxKeys argument was provided, and prevents
loading the truncated objects in that case.

On S3 this happens when using a bucket that has no special "folder objects"
(which are created by aus_driver_amazon_s3).

With MinIO it always happens, because HEAD requests fail for non-empty folders,
and thus listObjects is always used.