### PR TITLE
Set credentials only if provided in the storage configuration

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1126,12 +1126,14 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
         $configuration = [
             'version' => '2006-03-01',
             'region' => $this->configuration['region'] ?? '',
-            'credentials' => [
-                'key' => $this->configuration['key'] ?? '',
-                'secret' => $this->configuration['secretKey'] ?? '',
-            ],
             'validation' => false,
         ];
+        if (!empty($this->configuration['key']) || !empty($this->configuration['secretKey'])) {
+            $configuration['credentials'] = [
+                'key' => $this->configuration['key'] ?? '',
+                'secret' => $this->configuration['secretKey'] ?? '',
+            ];
+        }
         if (!empty($GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'])) {
             $configuration['http']['proxy'] = $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy'];
         }


### PR DESCRIPTION
If the credentials array-key exists in the configuration, the AWS SDK will always try to use that, even if key and secret are empty. By removing the credentials key completely, the S3 client will fall back to other authentication options: 

1. Load credentials from environment variables.
2. Load credentials from a credentials .ini file.
3. Load credentials from an IAM role

See: https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#credentials