### PR TITLE
Depreciated TYPO3_REQUEST handling

### DIFF
--- a/Classes/Service/CompatibilityService.php
+++ b/Classes/Service/CompatibilityService.php
@@ -35,7 +35,7 @@ class CompatibilityService implements SingletonInterface
             // Backwards compatibility: for TYPO3 versions lower than 11.0
             return TYPO3_MODE === 'BE';
         } else {
-            return ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend();
+            return (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend());
         }
     }
 
@@ -49,7 +49,7 @@ class CompatibilityService implements SingletonInterface
             // Backwards compatibility: for TYPO3 versions lower than 11.0
             return TYPO3_MODE === 'FE';
         } else {
-            return ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend();
+            return (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend());
         }
     }
 }


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92947-DeprecateTYPO3_MODEAndTYPO3_REQUESTTYPEConstants.html When trying to open "Remove Temporary Assets" from the install tool this was making Problem.