### PR TITLE
[BUGFIX] Fix deleting folders with subfolders

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -495,7 +495,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
                     if ($this->isDir($object['Key'])) {
                         $subFolder = $this->getFolder($object['Key']);
                         if ($subFolder) {
-                            $this->deleteFolder($subFolder, $deleteRecursively);
+                            $this->deleteFolder($subFolder->getIdentifier(), $deleteRecursively);
                         }
                     } else {
                         unlink($this->getStreamWrapperPath($object['Key']));


### PR DESCRIPTION
Instead of passing the folder path (identifier) to the deleteFolder() method, the object of the subfolder was passed.

This led to the exception "Instances of Aws\S3\S3Client cannot be serialized".

Test:
1. Create folder "subfolder1"
2. Within "subfolder1", create "subfolder2"
3. Upload a file into "subfolder2"
4. Delete "subfolder1".
