### PR TITLE
[BUGFIX] Make sure mime type is available when no property is specified

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -283,7 +283,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      */
     public function getFileInfoByIdentifier($fileIdentifier, array $propertiesToExtract = [])
     {
-        if (in_array('mimetype', $propertiesToExtract)) {
+        if (count($propertiesToExtract) === 0 || in_array('mimetype', $propertiesToExtract)) {
             // force to reload the infos from S3 if the mime type was requested
             $this->flushMetaInfoCache($fileIdentifier);
         }


### PR DESCRIPTION
The TYPO3 indexer in
`sysext/core/Classes/Resource/Index/Indexer.php#gatherFileInformationArray`
calls "getFileInfoByIdentifier" with an empty "$propertiesToExtract" array, which means it wants to have all information.

S3 driver did not yet return the mime type in that case, causing a crash:

> PHP Warning: Undefined array key "mime_type"
> in typo3/sysext/core/Classes/Resource/Index/Indexer.php line 323

So instead of only fetching the MIME type when it is explicitly requested, we also fetch it when no property has been given.

The error occured when a file was not in sys_file but already existed in storage - e.g. when the storage had been filled outside of TYPO3.