### PR TITLE
[BUGFIX] Make sure storage is loaded before accessing it

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1371,7 +1371,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
             return $this->getRootLevelFolder();
         }
         $this->normalizeIdentifier($identifier);
-        return new Folder($this->storage, $identifier, basename(rtrim($identifier, '/')));
+        return new Folder($this->getStorage(), $identifier, basename(rtrim($identifier, '/')));
     }
 
     /**


### PR DESCRIPTION
I cannot remember under which circumstances the storage was not yet initialized before it was used in getFolder(), but it surely is not bad to make sure it gets loaded when needed.