### PR TITLE
[BUGFIX] Properly distinguish CLI and backend mode

### DIFF
--- a/Classes/Service/CompatibilityService.php
+++ b/Classes/Service/CompatibilityService.php
@@ -33,10 +33,10 @@ class CompatibilityService implements SingletonInterface
     public function isBackend(): bool
     {
         if (Environment::isCli()) {
-            return true;
+            return false;
         }
-        return !isset($GLOBALS['TYPO3_REQUEST'])
-            || ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend();
+        return isset($GLOBALS['TYPO3_REQUEST'])
+            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend();
     }
 
     /**


### PR DESCRIPTION
The two methods that currently use `isBackend()` expect `$_GET` to contain stuff when `isBackend()` returns true. This is unlikely to be the case in CLI mode.