### PR TITLE
[BUGFIX] Create metadata record if necessary

### DIFF
--- a/Classes/Service/MetaDataUpdateService.php
+++ b/Classes/Service/MetaDataUpdateService.php
@@ -45,10 +45,15 @@ class MetaDataUpdateService implements SingletonInterface
             if ($imageDimensions !== null) {
                 $metaDataRepository = $this->getMetaDataRepository();
                 $metaData = $metaDataRepository->findByFileUid($fileProperties['uid']);
+                $create = count($metaData) === 0;
 
                 $metaData['width'] = $imageDimensions[0];
                 $metaData['height'] = $imageDimensions[1];
-                $metaDataRepository->update($fileProperties['uid'], $metaData);
+                if ($create) {
+                    $metaDataRepository->createMetaDataRecord($fileProperties['uid'], $metaData);
+                } else {
+                    $metaDataRepository->update($fileProperties['uid'], $metaData);
+                }
             }
         }
     }


### PR DESCRIPTION
When uploading a new file in TYPO3 v11.5.33, most of the times the meta data record has not been created yet when the MetaDataUpdateService is called.
This patch creates the meta data record when necessary, preventing the following error:

> (1/1) #1476107295 TYPO3\CMS\Core\Error\Exception
> PHP Warning: Undefined array key "uid" in typo3/sysext/core/Classes/Resource/Index/MetaDataRepository.php line 197
> Stack trace:
> #0 typo3/sysext/core/Classes/Resource/Index/MetaDataRepository.php(197): TYPO3\\CMS\\Core\\Error\\ErrorHandler->handleError()
> #1 typo3conf/ext/aus_driver_amazon_s3/Classes/Service/MetaDataUpdateService.php(51): TYPO3\\CMS\\Core\\Resource\\Index\\MetaDataRepository->update()
> #2 typo3conf/ext/aus_driver_amazon_s3/Classes/EventListener/AfterFileAddedToIndexEventListener.php(31): AUS\\AusDriverAmazonS3\\Service\\MetaDataUpdateService->updateMetadata()
> #3 typo3/sysext/core/Classes/EventDispatcher/EventDispatcher.php(51): AUS\\AusDriverAmazonS3\\EventListener\\AfterFileAddedToIndexEventListener->__invoke()
> #4 typo3/sysext/adminpanel/Classes/Service/EventDispatcher.php(41): TYPO3\\CMS\\Core\\EventDispatcher\\EventDispatcher->dispatch()
> #5 typo3/sysext/core/Classes/Resource/Index/FileIndexRepository.php(340): TYPO3\\CMS\\Adminpanel\\Service\\EventDispatcher->dispatch()
> #6 typo3/sysext/core/Classes/Resource/Index/FileIndexRepository.php(318): TYPO3\\CMS\\Core\\Resource\\Index\\FileIndexRepository->insertRecord()
> #7 typo3/sysext/core/Classes/Resource/Index/Indexer.php(84): TYPO3\\CMS\\Core\\Resource\\Index\\FileIndexRepository->addRaw()