### PR TITLE
[BUGFIX] Return dummy "mtime" attribute for folders

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -786,7 +786,8 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
         return [
             'identifier' => $folderIdentifier,
             'name' => basename(rtrim($folderIdentifier, '/')),
-            'storage' => $this->storageUid
+            'storage' => $this->storageUid,
+            'mtime' => null,
         ];
     }
 


### PR DESCRIPTION
TYPO3 v12 file list wants it

Part of: https://github.com/andersundsehr/aus_driver_amazon_s3/issues/135