### PR TITLE
Bugfix/redis cache backend

### DIFF
--- a/Classes/Service/MetaDataUpdateService.php
+++ b/Classes/Service/MetaDataUpdateService.php
@@ -42,12 +42,15 @@ class MetaDataUpdateService implements SingletonInterface
             $file = $storage->getFile($fileProperties['identifier']);
             $imageDimensions = $this->getExtractor()->getImageDimensionsOfRemoteFile($file);
 
-            if ($imageDimensions !== null) {
-                $metaDataRepository = $this->getMetaDataRepository();
-                $metaData = $metaDataRepository->findByFileUid($fileProperties['uid']);
+            $metaDataRepository = $this->getMetaDataRepository();
+            $metaData = $metaDataRepository->findByFileUid($fileProperties['uid']);
 
-                $metaData['width'] = $imageDimensions[0];
-                $metaData['height'] = $imageDimensions[1];
+            $create = count($metaData) === 0;
+            $metaData['width'] = $imageDimensions[0];
+            $metaData['height'] = $imageDimensions[1];
+            if ($create) {
+                $metaDataRepository->createMetaDataRecord($fileProperties['uid'], $metaData);
+            } else {
                 $metaDataRepository->update($fileProperties['uid'], $metaData);
             }
         }


### PR DESCRIPTION
In reaction to #63 i checked the extension using redis. If redis cache lifetime is overdue, it might report it still "has" an object, but getting it returns "false".

Also to allow persistent caches which might be a valid solution if all file transfers are passed through TYPO3, i removed the clear-cache call on initialization.