### PR TITLE
[FEATURE] Allow storage configuration override in config/system/addit…

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -218,7 +218,8 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      */
     public function initialize()
     {
-        $this->initializeBaseUrl()
+        $this->loadSettings()
+            ->initializeBaseUrl()
             ->initializeSettings()
             ->initializeClient();
         $this->resetRequestCache();
@@ -1052,6 +1053,32 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      *************************************************************/
 
     /**
+     * Load extension configuration and load additional storage configuration
+     *
+     * Record-based storage configuration can be overridden by defining
+     * $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['aus_driver_amazon_s3']['storage']
+     * or
+     * $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['aus_driver_amazon_s3']['storage_X']
+     * (where X is the UID of the storage record)
+     * in config/system/additional.php.
+     * This makes it possible to use environment variable based storage configuration.
+     */
+    protected function loadSettings(): self
+    {
+        self::$settings = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::EXTENSION_KEY);
+
+        //allow overriding storage configuration from AdditionalConfiguration.php
+        if (isset(self::$settings['storage'])) {
+            $this->configuration = array_merge($this->configuration, self::$settings['storage']);
+        }
+        if (isset(self::$settings['storage_' . $this->storageUid])) {
+            $this->configuration = array_merge($this->configuration, self::$settings['storage_' . $this->storageUid]);
+        }
+
+        return $this;
+    }
+
+    /**
      * initializeBaseUrl
      *
      * @return $this
@@ -1091,15 +1118,11 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      */
     protected function initializeSettings()
     {
-        if (self::$settings === null) {
-            self::$settings = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::EXTENSION_KEY);
-
-            if (!isset(self::$settings['doNotLoadAmazonLib']) || !self::$settings['doNotLoadAmazonLib']) {
-                self::loadExternalClasses();
-            }
-            if ($this->compatibilityService->isFrontend() && (!isset(self::$settings['dnsPrefetch']) || self::$settings['dnsPrefetch'])) {
-                $GLOBALS['TSFE']->additionalHeaderData['ausDriverAmazonS3_dnsPrefetch'] = '<link rel="dns-prefetch" href="' . $this->baseUrl . '">';
-            }
+        if (!isset(self::$settings['doNotLoadAmazonLib']) || !self::$settings['doNotLoadAmazonLib']) {
+            self::loadExternalClasses();
+        }
+        if ($this->compatibilityService->isFrontend() && (!isset(self::$settings['dnsPrefetch']) || self::$settings['dnsPrefetch'])) {
+            $GLOBALS['TSFE']->additionalHeaderData['ausDriverAmazonS3_dnsPrefetch'] = '<link rel="dns-prefetch" href="' . $this->baseUrl . '">';
         }
         return $this;
     }


### PR DESCRIPTION
…ional.php

Record-based storage configuration can be overridden by defining
  `$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['aus_driver_amazon_s3']['storage']`
or
  `$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['aus_driver_amazon_s3']['storage_X']`
(where X is the UID of the storage record)
in config/system/additional.php.

This makes it possible to use environment variable based storage configuration, and no secret keys need to be stored in the database anymore.

Storage configuration in the database record is merged with the generic 'storage' configuration, which then with the uid-specific storage config.

Example for defining the credentials in config/system/additional.php:
```
$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['aus_driver_amazon_s3']['storage_23'] = [
    'key'       => $_ENV['S3_KEY'],
    'secretKey' => $_ENV['S3_SECRET'],
];
```