### PR TITLE
[BUGFIX] Append slash to folder identifiers

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -343,12 +343,14 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      * Checks if a folder exists inside a storage folder
      *
      * @param string $folderName
-     * @param string $folderIdentifier
+     * @param string $folderIdentifier Parent folder
      * @return bool
      */
     public function folderExistsInFolder($folderName, $folderIdentifier)
     {
-        return $this->prefixExists(rtrim($folderIdentifier, '/') . '/' . $folderName . '/');
+        $identifier = rtrim($folderIdentifier, '/') . '/' . $folderName;
+        $this->normalizeFolderIdentifier($identifier);
+        return $this->prefixExists($identifier);
     }
 
     /**
@@ -360,8 +362,8 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      */
     public function getFolderInFolder($folderName, $folderIdentifier)
     {
-        $identifier = $folderIdentifier . '/' . $folderName . '/';
-        $this->normalizeIdentifier($identifier);
+        $identifier = $folderIdentifier . '/' . $folderName;
+        $this->normalizeFolderIdentifier($identifier);
         return $identifier;
     }
 
@@ -425,6 +427,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      */
     public function moveFileWithinStorage($fileIdentifier, $targetFolderIdentifier, $newFileName)
     {
+        $this->normalizeFolderIdentifier($targetFolderIdentifier);
         $targetIdentifier = $targetFolderIdentifier . $newFileName;
         $this->renameObject($fileIdentifier, $targetIdentifier);
         return $targetIdentifier;
@@ -734,14 +737,22 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
         $result = $this->getListObjects(
             $folderIdentifier,
             [
-                'MaxKeys' => 1
+                'MaxKeys' => 2
             ]
         );
 
-        // Contents will always include the folder itself
-        if (isset($result['Contents']) && sizeof($result['Contents']) > 1) {
+        //MinIO does not return the folder itself, but S3 does.
+        // Unify the results and remove the folder itself.
+        if (isset($result['Contents']) && count($result['Contents'])) {
+            if ($result['Contents'][0]['Key'] == $folderIdentifier) {
+                unset($result['Contents'][0]);
+            }
+        }
+
+        if (isset($result['Contents']) && count($result['Contents']) > 0) {
             return false;
         }
+
         return true;
     }
 
@@ -785,7 +796,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
         $this->normalizeIdentifier($folderIdentifier);
 
         return [
-            'identifier' => $folderIdentifier,
+            'identifier' => rtrim($folderIdentifier, '/') . '/',
             'name' => basename(rtrim($folderIdentifier, '/')),
             'storage' => $this->storageUid,
             'mtime' => null,
@@ -826,7 +837,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      */
     public function getFilesInFolder($folderIdentifier, $start = 0, $numberOfItems = 0, $recursive = false, array $filenameFilterCallbacks = [], $sort = '', $sortRev = false)
     {
-        $this->normalizeIdentifier($folderIdentifier);
+        $this->normalizeFolderIdentifier($folderIdentifier);
         $files = [];
         if ($folderIdentifier === self::ROOT_FOLDER_IDENTIFIER) {
             $folderIdentifier = '';
@@ -1386,7 +1397,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
             return $this->getRootLevelFolder();
         }
         $this->normalizeIdentifier($identifier);
-        return new Folder($this->getStorage(), $identifier, basename(rtrim($identifier, '/')));
+        return new Folder($this->getStorage(), rtrim($identifier, '/') . '/', basename(rtrim($identifier, '/')));
     }
 
     /**
@@ -1469,6 +1480,22 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
         $identifier = str_replace('//', '/', $identifier);
         if ($identifier !== '/') {
             $identifier = ltrim($identifier, '/');
+        }
+    }
+
+    /**
+     * Appends a slash at the end if missing
+     *
+     * @param string &$identifier
+     */
+    protected function normalizeFolderIdentifier(&$identifier)
+    {
+        $this->normalizeIdentifier($identifier);
+        if ($identifier !== '/') {
+            $identifier = rtrim($identifier, '/') . '/';
+        }
+        if ($identifier === '/') {
+            $identifier = '';
         }
     }
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: functional-tests tests unit-tests
+
+tests: unit-tests functional-tests
+
+functional-tests: .Build/bin/phpunit .Build/Web/typo3conf/ext/aus_driver_amazon_s3
+	 ./Build/Scripts/runTests.sh -p 8.2 -d sqlite -s functional\
+	    -e "--display-warnings --display-notices --display-errors"
+
+unit-tests: .Build/bin/phpunit .Build/Web/typo3conf/ext/aus_driver_amazon_s3
+	 ./Build/Scripts/runTests.sh -p 8.2 -d sqlite -s unit\
+	    -e "--display-warnings --display-notices --display-errors"
+
+.Build/bin/phpunit:
+	composer install
+
+.Build/Web/typo3conf/ext/aus_driver_amazon_s3:
+	mkdir -p .Build/Web/typo3conf/ext/
+	ln -sfn ../../../../ .Build/Web/typo3conf/ext/aus_driver_amazon_s3

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Edit in “Extension Manager” the following extension settings:
 
 # Customizing TYPO3 Cache Backends
 
-- `ausdriveramazons3_metainfocache` retains metadata from AWS S3 on a per-object basis. 
+- `ausdriveramazons3_metainfocache` retains metadata from AWS S3 on a per-object basis.
 - `ausdriveramazons3_requestcache` stores the complete response of a specific request, facilitating efficient data access and performance enhancement.
 
 By default, these caches are transient. However, if you choose to configure a persistent cache backend, it's crucial to remember that such a cache will not automatically recognize changes from the data source. In this case, it becomes your responsibility to implement the necessary updates manually.
@@ -170,3 +170,10 @@ You can modify the parameter "cacheControl" as you wish. Please Notice: AWS S3 s
 ### More
 
 If you wish other hooks - don’t be shy: [GitHub issue tracking: Amazon S3 FAL Driver](https://github.com/andersundsehr/aus_driver_amazon_s3/issues)
+
+
+# Development
+
+## Running tests
+
+Run `make tests` to run both unit and functional tests.

--- a/Tests/Functional/Driver/AmazonS3DriverTest.php
+++ b/Tests/Functional/Driver/AmazonS3DriverTest.php
@@ -100,8 +100,6 @@ class AmazonS3DriverTest extends FunctionalTestCase
 
         $this->assertTrue($this->driver->deleteFolder('tmp-dir/'));
         $this->assertFalse($this->driver->folderExists('tmp-dir'));
-
-        $this->markTestSkipped('deleteFolder("tmp-dir/") fails currently');
     }
 
     public function testFileExists()
@@ -126,7 +124,8 @@ class AmazonS3DriverTest extends FunctionalTestCase
 
     public function testFolderExistsInFolder()
     {
-        $this->markTestSkipped('Currently broken: leading slash must be removed');
+        $this->assertTrue($this->driver->folderExistsInFolder('subfolder11', 'folder1'));
+
         $this->assertTrue(
             $this->driver->folderExistsInFolder(
                 'images',
@@ -198,14 +197,12 @@ class AmazonS3DriverTest extends FunctionalTestCase
 
     public function testIsFolderEmptySlash()
     {
-        $this->markTestSkipped('Currently broken');
         $this->assertCount(1, $this->driver->getFilesInFolder('images/'));
         $this->assertFalse($this->driver->isFolderEmpty('images/'));
     }
 
     public function testIsFolderEmptyNoSlash()
     {
-        $this->markTestSkipped('Slash is not added automatically');
         $this->assertCount(1, $this->driver->getFilesInFolder('images'));
         $this->assertFalse($this->driver->isFolderEmpty('images'));
     }
@@ -258,8 +255,6 @@ class AmazonS3DriverTest extends FunctionalTestCase
 
     public function testMoveFileWithinStorageSubfolderNoSlash()
     {
-        $this->markTestSkipped('moving to "images" folder with slash fails currently');
-
         $this->assertTrue($this->driver->fileExists('23.txt'));
         $this->assertFalse($this->driver->fileExists('images/movetarget.txt'));
         $this->assertEquals(


### PR DESCRIPTION
This patch fixes the problem that fetching a folder via API and using that to upload a file put the file into the wrong folder:

    $folder = $storage->getFolder('myfolder');
    $storage->addFile('/tmp/file.txt', $folder, 'file.txt');
    //created "/myfolderfile.txt" instead of "/myfolder/file.txt"

TYPO3's own
`AbstractHierarchicalFilesystemDriver::canonicalizeAndCheckFolderIdentifier` appends slashes,
and our `createFolder()` already returned identifiers with slashes at the end.

Resolves: https://github.com/andersundsehr/aus_driver_amazon_s3/issues/146