### PR TITLE
[BUGFIX] Do not crash when moving empty folder

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1487,7 +1487,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
     protected function getSubObjects($identifier, $recursive = true, $filter = self::FILTER_ALL)
     {
         $result = $this->getListObjects($identifier);
-        if (!is_array($result['Contents'])) {
+        if (!is_array($result['Contents'] ?? null)) {
             return [];
         }
         return array_filter($result['Contents'], function (&$object) use ($identifier, $recursive, $filter) {


### PR DESCRIPTION
At least MinIO's list response does not contain a 'Content' property when a folder has no child elements.

When moving a folder, check for its existence before iterating over it.

Resolves: https://github.com/andersundsehr/aus_driver_amazon_s3/issues/148