### PR TITLE
[TASK] Ignore Code style fixes/reformattings in "git blame"

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# [TASK] Reformat code to PSR-2
+7a5e50557f1270217fd016e2035bad3171eb1b73


### PR DESCRIPTION
This shows the real change commit when running "git blame" instead of showing the commit where the code style was changed.

This needs to be enabled on a per-checkout basis with

    $ git config blame.ignoreRevsFile .git-blame-ignore-revs

See
https://git-scm.com/docs/git-config#Documentation/git-config.txt-blameignoreRevsFile