### PR TITLE
[BUGFIX] Fix moving and copying files into a new folder

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -426,7 +426,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      */
     public function moveFileWithinStorage($fileIdentifier, $targetFolderIdentifier, $newFileName)
     {
-        $targetIdentifier = $targetFolderIdentifier . $newFileName;
+        $targetIdentifier = $targetFolderIdentifier . '/' . $newFileName;
         $this->renameObject($fileIdentifier, $targetIdentifier);
         return $targetIdentifier;
     }
@@ -443,7 +443,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      */
     public function copyFileWithinStorage($fileIdentifier, $targetFolderIdentifier, $fileName)
     {
-        $targetIdentifier = $targetFolderIdentifier . $fileName;
+        $targetIdentifier = $targetFolderIdentifier . '/' . $fileName;
         $this->copyObject($fileIdentifier, $targetIdentifier);
         return $targetIdentifier;
     }


### PR DESCRIPTION
The AmazonS3Driver for move and copy operation creates target file identifier by concatenating target folder identifier and target file name:

```
$targetIdentifier = $targetFolderIdentifier . $newFileName;
```

This is wrong as it will just rename the current file by appending to the name the  target folder indentifer (due to concatenation used).

This commit fixes this bug by adding `/` between target folder identiifer and the file name:

```
$targetIdentifier = $targetFolderIdentifier . '/' . $newFileName;
```