### PR TITLE
[BUGFIX] Use different cache keys for different bucket URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: functional-tests tests unit-tests
+
+tests: unit-tests functional-tests
+
+functional-tests: .Build/bin/phpunit .Build/Web/typo3conf/ext/aus_driver_amazon_s3
+	 ./Build/Scripts/runTests.sh -p 8.2 -d sqlite -s functional\
+	    -e "--display-warnings --display-notices --display-errors"
+
+unit-tests: .Build/bin/phpunit .Build/Web/typo3conf/ext/aus_driver_amazon_s3
+	 ./Build/Scripts/runTests.sh -p 8.2 -d sqlite -s unit\
+	    -e "--display-warnings --display-notices --display-errors"
+
+.Build/bin/phpunit:
+	composer install
+
+.Build/Web/typo3conf/ext/aus_driver_amazon_s3:
+	mkdir -p .Build/Web/typo3conf/ext/
+	ln -sfn ../../../../ .Build/Web/typo3conf/ext/aus_driver_amazon_s3

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Edit in “Extension Manager” the following extension settings:
 
 # Customizing TYPO3 Cache Backends
 
-- `ausdriveramazons3_metainfocache` retains metadata from AWS S3 on a per-object basis. 
+- `ausdriveramazons3_metainfocache` retains metadata from AWS S3 on a per-object basis.
 - `ausdriveramazons3_requestcache` stores the complete response of a specific request, facilitating efficient data access and performance enhancement.
 
 By default, these caches are transient. However, if you choose to configure a persistent cache backend, it's crucial to remember that such a cache will not automatically recognize changes from the data source. In this case, it becomes your responsibility to implement the necessary updates manually.
@@ -170,3 +170,10 @@ You can modify the parameter "cacheControl" as you wish. Please Notice: AWS S3 s
 ### More
 
 If you wish other hooks - don’t be shy: [GitHub issue tracking: Amazon S3 FAL Driver](https://github.com/andersundsehr/aus_driver_amazon_s3/issues)
+
+
+# Development
+
+## Running tests
+
+Run `make tests` to run both unit and functional tests.


### PR DESCRIPTION
When having multiple S3-based storages in TYPO3, the file tree view shows the same folders for all storages since commit
> 6d01c1abea2741692a5254ce487ed007eaebfebd
> Make some caches configurable, fixes a caching issue
> and minor performance improvements

The culprit is that the caching layer does not take the bucket configuration into account, leading to the same cache key "/" for all storages.

This commit uses the S3 client endpoint as prefix for all cache keys.

![2024-12-12 typo3 dateiliste](https://github.com/user-attachments/assets/29a250db-9e43-49ef-ae79-333bb3a24002)
