### PR TITLE
V13 compatibility

### DIFF
--- a/Classes/Index/Extractor.php
+++ b/Classes/Index/Extractor.php
@@ -38,7 +38,7 @@ class Extractor implements ExtractorInterface
      */
     public function getFileTypeRestrictions()
     {
-        return [File::FILETYPE_IMAGE];
+        return [\TYPO3\CMS\Core\Resource\FileType::IMAGE];
     }
 
     /**
@@ -91,7 +91,7 @@ class Extractor implements ExtractorInterface
      */
     public function canProcess(File $file)
     {
-        return $file->getType() == File::FILETYPE_IMAGE && $file->getStorage()->getDriverType() === AmazonS3Driver::DRIVER_TYPE;
+        return $file->getType() == \TYPO3\CMS\Core\Resource\FileType::IMAGE && $file->getStorage()->getDriverType() === AmazonS3Driver::DRIVER_TYPE;
     }
 
     /**

--- a/Classes/Service/MetaDataUpdateService.php
+++ b/Classes/Service/MetaDataUpdateService.php
@@ -35,7 +35,7 @@ class MetaDataUpdateService implements SingletonInterface
      */
     public function updateMetadata(array $fileProperties): void
     {
-        if ($fileProperties['type'] !== AbstractFile::FILETYPE_IMAGE) {
+        if ($fileProperties['type'] !== \TYPO3\CMS\Core\Resource\FileType::IMAGE) {
             return;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "license": "LGPL-3.0-or-later",
   "require": {
     "php": ">=7.4",
-    "typo3/cms-core": "^11.5.6 || ^12.4.5",
+    "typo3/cms-core": "^11.5.6 || ^12.4.5 || ^13.4",
     "aws/aws-sdk-php": "^3.288"
   },
   "require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -5,7 +5,7 @@ $EM_CONF[$_EXTKEY] = [
     'title' => 'Amazon AWS S3 FAL driver (CDN)',
     'description' => 'Provides a FAL driver for the Amazon Web Service S3.',
     'category' => 'be',
-    'version' => '1.12.1',
+    'version' => '1.13.0',
     'state' => 'stable',
     'uploadfolder' => false,
     'createDirs' => '',
@@ -17,7 +17,7 @@ $EM_CONF[$_EXTKEY] = [
         [
             'depends' =>
                 [
-                    'typo3' => '11.5.30-12.4.99',
+                    'typo3' => '11.5.30-13.4.99',
                 ],
             'conflicts' => [],
             'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -13,12 +13,23 @@ $driverRegistry->registerDriverClass(
 // register extractor
 \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::class)->registerExtractionService(\AUS\AusDriverAmazonS3\Index\Extractor::class);
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_metainfocache'] = [
-    'backend' => \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class,
-    'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
-];
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_metainfocache'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_metainfocache'] = [];
+}
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_requestcache'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_requestcache'] = [];
+}
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_requestcache'] = [
-    'backend' => \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class,
-    'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
-];
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_metainfocache']['backend'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_metainfocache']['backend'] = \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class;
+}
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_requestcache']['backend'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_requestcache']['backend'] = \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class;
+}
+
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_metainfocache']['frontend'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_metainfocache']['frontend'] = \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class;
+}
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_requestcache']['frontend'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ausdriveramazons3_requestcache']['frontend'] = \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class;
+}


### PR DESCRIPTION
- fix an issue where getFileForLocalProcessing tries to download an inexistent file from the bucket. Issue appeared between 13.4.9 and 13.4.10.
- prevent the default cache configuration to overwrite local configuration