### PR TITLE
Update PHPDoc comment for $metaInfoCache

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -102,8 +102,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
     protected $identifierMap = [];
 
     /**
-     * Object meta data is cached here as array or null
-     * $identifier => [meta info as array]
+     * Object meta data is cached here
      *
      * @var FrontendInterface
      */


### PR DESCRIPTION
This cache was changed from an array to a Typo3 cache object in pull request #131.