### PR TITLE
Fix growing var/transient folder contents to get (image) sizes

### DIFF
--- a/Classes/Index/Extractor.php
+++ b/Classes/Index/Extractor.php
@@ -18,6 +18,7 @@ use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Resource\Index\ExtractorInterface;
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Type\File\ImageInfo;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -28,8 +29,13 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author Stefan Lamm <s.lamm@andersundsehr.com>
  * @package AUS\AusDriverAmazonS3\Index
  */
-class Extractor implements ExtractorInterface
+class Extractor implements ExtractorInterface, SingletonInterface
 {
+    /**
+     * @var array<string, array<int>>
+     */
+    private array $cache = [];
+
     /**
      * Returns an array of supported file types;
      * An empty array indicates all filetypes
@@ -122,11 +128,19 @@ class Extractor implements ExtractorInterface
      */
     public function getImageDimensionsOfRemoteFile(FileInterface $file): array
     {
+        if (isset($this->cache[$file->getIdentifier()])) {
+            return $this->cache[$file->getIdentifier()];
+        }
+
         $fileNameAndPath = $file->getForLocalProcessing(false);
         $imageInfo = GeneralUtility::makeInstance(ImageInfo::class, $fileNameAndPath);
-        return [
+        $sizes = [
             $imageInfo->getWidth(),
             $imageInfo->getHeight(),
         ];
+
+        $this->cache[$file->getIdentifier()] = $sizes;
+        GeneralUtility::unlink_tempfile($fileNameAndPath);
+        return $sizes;
     }
 }

--- a/Classes/Index/Extractor.php
+++ b/Classes/Index/Extractor.php
@@ -135,9 +135,12 @@ class Extractor implements ExtractorInterface
      */
     public function getImageDimensionsOfRemoteFile(FileInterface $file): array
     {
-        $identifier = sha1($file->getIdentifier());
+        $identifier = 'andersundsehr_aus_driver_amazon_s3_' . sha1($file->getIdentifier());
         if ($this->cache?->has($identifier)) {
-            return $this->cache->get($identifier);
+            $sizes = $this->cache->get($identifier);
+            if (is_array($sizes) && count($sizes) === 2) {
+                return $sizes;
+            }
         }
 
         $fileNameAndPath = $file->getForLocalProcessing(false);

--- a/Classes/Index/Extractor.php
+++ b/Classes/Index/Extractor.php
@@ -15,10 +15,12 @@
 namespace AUS\AusDriverAmazonS3\Index;
 
 use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Resource\Index\ExtractorInterface;
-use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Type\File\ImageInfo;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -29,12 +31,17 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author Stefan Lamm <s.lamm@andersundsehr.com>
  * @package AUS\AusDriverAmazonS3\Index
  */
-class Extractor implements ExtractorInterface, SingletonInterface
+class Extractor implements ExtractorInterface
 {
-    /**
-     * @var array<string, array<int>>
-     */
-    private array $cache = [];
+    private ?FrontendInterface $cache = null;
+
+    public function __construct()
+    {
+        try {
+            $this->cache = GeneralUtility::makeInstance(CacheManager::class)->getCache('runtime');
+        } catch (NoSuchCacheException) {
+        }
+    }
 
     /**
      * Returns an array of supported file types;
@@ -128,8 +135,9 @@ class Extractor implements ExtractorInterface, SingletonInterface
      */
     public function getImageDimensionsOfRemoteFile(FileInterface $file): array
     {
-        if (isset($this->cache[$file->getIdentifier()])) {
-            return $this->cache[$file->getIdentifier()];
+        $identifier = sha1($file->getIdentifier());
+        if ($this->cache?->has($identifier)) {
+            return $this->cache->get($identifier);
         }
 
         $fileNameAndPath = $file->getForLocalProcessing(false);
@@ -139,7 +147,7 @@ class Extractor implements ExtractorInterface, SingletonInterface
             $imageInfo->getHeight(),
         ];
 
-        $this->cache[$file->getIdentifier()] = $sizes;
+        $this->cache?->set($identifier, $sizes);
         GeneralUtility::unlink_tempfile($fileNameAndPath);
         return $sizes;
     }

--- a/README.md
+++ b/README.md
@@ -177,3 +177,12 @@ If you wish other hooks - don’t be shy: [GitHub issue tracking: Amazon S3 FAL 
 ## Running tests
 
 Run `make tests` to run both unit and functional tests.
+
+To switch TYPO3 test version to 11:
+```bash
+composer update --with typo3/cms-core:^11.5.6
+```
+To switch TYPO3 test version to 12:
+```bash
+composer update --with typo3/cms-core:^12.4.0 --ignore-platform-req=ext-intl
+```

--- a/Tests/Unit/S3Adapter/MetaInfoDownloadAdapterTest.php
+++ b/Tests/Unit/S3Adapter/MetaInfoDownloadAdapterTest.php
@@ -19,6 +19,7 @@ use Aws\Api\DateTimeResult;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Resource\MimeTypeCompatibilityTypeGuesser;
 use TYPO3\CMS\Core\Type\File\FileInfo;
 use TYPO3\CMS\Core\Utility\PathUtility;
@@ -52,7 +53,9 @@ class MetaInfoDownloadAdapterTest extends TestCase
         parent::setUp();
         $this->metaInfoDownloadAdapter = new MetaInfoDownloadAdapter();
         $this->driver = $this->prophesize(AmazonS3Driver::class);
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][FileInfo::class]['mimeTypeGuessers'][MimeTypeCompatibilityTypeGuesser::class] = MimeTypeCompatibilityTypeGuesser::class . '->guessMimeType';
+        if ((new Typo3Version())->getMajorVersion() > 11) {
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][FileInfo::class]['mimeTypeGuessers'][MimeTypeCompatibilityTypeGuesser::class] = MimeTypeCompatibilityTypeGuesser::class . '->guessMimeType';
+        }
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require-dev": {
     "pluswerk/grumphp-config": "^5.0",
-    "typo3/testing-framework": "^8.0",
+    "typo3/testing-framework": "*",
     "phpspec/prophecy": "dev-master",
     "phpspec/prophecy-phpunit": "dev-master",
     "saschaegerer/phpstan-typo3": "^1.8.9",

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,16 @@
   },
   "license": "LGPL-3.0-or-later",
   "require": {
-    "php": ">=7.4",
-    "typo3/cms-core": "^11.5.6 || ^12.4.5",
+    "php": ">=8.2.0 <8.5.0",
+    "typo3/cms-core": "~v11.5.41 || ~v12.4.36",
     "aws/aws-sdk-php": "^3.288"
   },
   "require-dev": {
     "pluswerk/grumphp-config": "^5.0",
-    "typo3/testing-framework": "*",
-    "phpspec/prophecy": "dev-master",
-    "phpspec/prophecy-phpunit": "dev-master",
-    "saschaegerer/phpstan-typo3": "^1.8.9",
+    "typo3/testing-framework": "^7.1.1 || ^8.2.7",
+    "phpspec/prophecy": "^1.22.0",
+    "phpspec/prophecy-phpunit": "^2.4.0",
+    "saschaegerer/phpstan-typo3": "^1.10.2",
     "ssch/typo3-rector": "^1.3.5"
   },
   "autoload": {


### PR DESCRIPTION
Fixes Issue https://github.com/andersundsehr/aus_driver_amazon_s3/issues/156

also getImageDimensionsOfRemoteFile is called twice with the same identifier, so singleton provides a small "runtime cache"