### PR TITLE
[BUGFIX] use AND comparison when merging capabilities

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1078,19 +1078,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      */
     public function mergeConfigurationCapabilities(Capabilities $capabilities): Capabilities
     {
-        $allCapabilities = [
-            Capabilities::CAPABILITY_BROWSABLE,
-            Capabilities::CAPABILITY_PUBLIC,
-            Capabilities::CAPABILITY_WRITABLE,
-            Capabilities::CAPABILITY_HIERARCHICAL_IDENTIFIERS,
-        ];
-
-        foreach ($allCapabilities as $capability) {
-            if ($capabilities->hasCapability($capability)) {
-                $this->capabilities->addCapabilities($capability);
-            }
-        }
-
+        $this->capabilities->and($capabilities);
         return $this->capabilities;
     }
 


### PR DESCRIPTION
When merging the capabilities, the driver's capabilities were always added to the configuration's capabilities. As a result of that, it was not possible to create a S3 storage that is not public.
With this change, the logical AND operation provided by `TYPO3\CMS\Core\Type\BitSet` is used to correctly merge the capabilities.