### PR TITLE
Make sure the $GLOBALS['TSFE'] is set before using it

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1191,7 +1191,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
         $this->initializeBaseUrl();
         $this->initializeBaseFolder();
 
-        if ($this->compatibilityService->isFrontend() && (!isset(self::$settings['dnsPrefetch']) || self::$settings['dnsPrefetch'])) {
+        if (isset($GLOBALS['TSFE']) && $this->compatibilityService->isFrontend() && (!isset(self::$settings['dnsPrefetch']) || self::$settings['dnsPrefetch'])) {
             $GLOBALS['TSFE']->additionalHeaderData['ausDriverAmazonS3_dnsPrefetch'] = '<link rel="dns-prefetch" href="' . $this->baseUrl . '">';
         }
         return $this;


### PR DESCRIPTION
Hello,
after thousands of runs, I noticed that it very rarely triggered this if statement even though the variable “$GLOBALS['TSFE']” wasn't set.