### PR TITLE
Fix FlexForm TCA deprecations

### DIFF
--- a/Configuration/FlexForm/AmazonS3DriverFlexForm.xml
+++ b/Configuration/FlexForm/AmazonS3DriverFlexForm.xml
@@ -24,112 +24,112 @@
                     <renderType>selectSingle</renderType>
                     <items type="array">
                         <numIndex index="0" type="array">
-                            <numIndex index="0">US East (Ohio) - us-east-2</numIndex>
-                            <numIndex index="1">us-east-2</numIndex>
+                            <label>US East (Ohio) - us-east-2</label>
+                            <value>us-east-2</value>
                         </numIndex>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">US East (N. Virginia) - us-east-1</numIndex>
-                            <numIndex index="1">us-east-1</numIndex>
+                            <label>US East (N. Virginia) - us-east-1</label>
+                            <value>us-east-1</value>
                         </numIndex>
                         <numIndex index="2" type="array">
-                            <numIndex index="0">US West (N. California) - us-west-1</numIndex>
-                            <numIndex index="1">us-west-1</numIndex>
+                            <label>US West (N. California) - us-west-1</label>
+                            <value>us-west-1</value>
                         </numIndex>
                         <numIndex index="3" type="array">
-                            <numIndex index="0">US West (Oregon) - us-west-2</numIndex>
-                            <numIndex index="1">us-west-2</numIndex>
+                            <label>US West (Oregon) - us-west-2</label>
+                            <value>us-west-2</value>
                         </numIndex>
                         <numIndex index="4" type="array">
-                            <numIndex index="0">Africa (Cape Town) - af-south-1</numIndex>
-                            <numIndex index="1">af-south-1</numIndex>
+                            <label>Africa (Cape Town) - af-south-1</label>
+                            <value>af-south-1</value>
                         </numIndex>
                         <numIndex index="5" type="array">
-                            <numIndex index="0">Asia Pacific (Hong Kong) - ap-east-1</numIndex>
-                            <numIndex index="1">ap-east-1</numIndex>
+                            <label>Asia Pacific (Hong Kong) - ap-east-1</label>
+                            <value>ap-east-1</value>
                         </numIndex>
                         <numIndex index="6" type="array">
-                            <numIndex index="0">Asia Pacific (Jakarta) - ap-southeast-3</numIndex>
-                            <numIndex index="1">ap-southeast-3</numIndex>
+                            <label>Asia Pacific (Jakarta) - ap-southeast-3</label>
+                            <value>ap-southeast-3</value>
                         </numIndex>
                         <numIndex index="7" type="array">
-                            <numIndex index="0">Asia Pacific (Mumbai) - ap-south-1</numIndex>
-                            <numIndex index="1">ap-south-1</numIndex>
+                            <label>Asia Pacific (Mumbai) - ap-south-1</label>
+                            <value>ap-south-1</value>
                         </numIndex>
                         <numIndex index="8" type="array">
-                            <numIndex index="0">Asia Pacific (Osaka) - ap-northeast-3</numIndex>
-                            <numIndex index="1">ap-northeast-3</numIndex>
+                            <label>Asia Pacific (Osaka) - ap-northeast-3</label>
+                            <value>ap-northeast-3</value>
                         </numIndex>
                         <numIndex index="9" type="array">
-                            <numIndex index="0">Asia Pacific (Seoul) - ap-northeast-2</numIndex>
-                            <numIndex index="1">ap-northeast-2</numIndex>
+                            <label>Asia Pacific (Seoul) - ap-northeast-2</label>
+                            <value>ap-northeast-2</value>
                         </numIndex>
                         <numIndex index="10" type="array">
-                            <numIndex index="0">Asia Pacific (Singapore) - ap-southeast-1</numIndex>
-                            <numIndex index="1">ap-southeast-1</numIndex>
+                            <label>Asia Pacific (Singapore) - ap-southeast-1</label>
+                            <value>ap-southeast-1</value>
                         </numIndex>
                         <numIndex index="11" type="array">
-                            <numIndex index="0">Asia Pacific (Sydney) - ap-southeast-2</numIndex>
-                            <numIndex index="1">ap-southeast-2</numIndex>
+                            <label>Asia Pacific (Sydney) - ap-southeast-2</label>
+                            <value>ap-southeast-2</value>
                         </numIndex>
                         <numIndex index="12" type="array">
-                            <numIndex index="0">Asia Pacific (Tokyo) - ap-northeast-1</numIndex>
-                            <numIndex index="1">ap-northeast-1</numIndex>
+                            <label>Asia Pacific (Tokyo) - ap-northeast-1</label>
+                            <value>ap-northeast-1</value>
                         </numIndex>
                         <numIndex index="13" type="array">
-                            <numIndex index="0">Canada (Central) - ca-central-1</numIndex>
-                            <numIndex index="1">ca-central-1</numIndex>
+                            <label>Canada (Central) - ca-central-1</label>
+                            <value>ca-central-1</value>
                         </numIndex>
                         <numIndex index="14" type="array">
-                            <numIndex index="0">China (Beijing) - cn-north-1</numIndex>
-                            <numIndex index="1">cn-north-1</numIndex>
+                            <label>China (Beijing) - cn-north-1</label>
+                            <value>cn-north-1</value>
                         </numIndex>
                         <numIndex index="15" type="array">
-                            <numIndex index="0">China (Ningxia) - cn-northwest-1</numIndex>
-                            <numIndex index="1">cn-northwest-1</numIndex>
+                            <label>China (Ningxia) - cn-northwest-1</label>
+                            <value>cn-northwest-1</value>
                         </numIndex>
                         <numIndex index="16" type="array">
-                            <numIndex index="0">Europe (Frankfurt) - eu-central-1</numIndex>
-                            <numIndex index="1">eu-central-1</numIndex>
+                            <label>Europe (Frankfurt) - eu-central-1</label>
+                            <value>eu-central-1</value>
                         </numIndex>
                         <numIndex index="17" type="array">
-                            <numIndex index="0">Europe (Ireland) - eu-west-1</numIndex>
-                            <numIndex index="1">eu-west-1</numIndex>
+                            <label>Europe (Ireland) - eu-west-1</label>
+                            <value>eu-west-1</value>
                         </numIndex>
                         <numIndex index="18" type="array">
-                            <numIndex index="0">Europe (London) - eu-west-2</numIndex>
-                            <numIndex index="1">eu-west-2</numIndex>
+                            <label>Europe (London) - eu-west-2</label>
+                            <value>eu-west-2</value>
                         </numIndex>
                         <numIndex index="19" type="array">
-                            <numIndex index="0">Europe (Milan) - eu-south-1</numIndex>
-                            <numIndex index="1">eu-south-1</numIndex>
+                            <label>Europe (Milan) - eu-south-1</label>
+                            <value>eu-south-1</value>
                         </numIndex>
                         <numIndex index="20" type="array">
-                            <numIndex index="0">Europe (Paris) - eu-west-3</numIndex>
-                            <numIndex index="1">eu-west-3</numIndex>
+                            <label>Europe (Paris) - eu-west-3</label>
+                            <value>eu-west-3</value>
                         </numIndex>
                         <numIndex index="21" type="array">
-                            <numIndex index="0">Europe (Stockholm) - eu-north-1</numIndex>
-                            <numIndex index="1">eu-north-1</numIndex>
+                            <label>Europe (Stockholm) - eu-north-1</label>
+                            <value>eu-north-1</value>
                         </numIndex>
                         <numIndex index="22" type="array">
-                            <numIndex index="0">South America (São Paulo) - sa-east-1</numIndex>
-                            <numIndex index="1">sa-east-1</numIndex>
+                            <label>South America (São Paulo) - sa-east-1</label>
+                            <value>sa-east-1</value>
                         </numIndex>
                         <numIndex index="23" type="array">
-                            <numIndex index="0">Middle East (Bahrain) - me-south-1</numIndex>
-                            <numIndex index="1">me-south-1</numIndex>
+                            <label>Middle East (Bahrain) - me-south-1</label>
+                            <value>me-south-1</value>
                         </numIndex>
                         <numIndex index="24" type="array">
-                            <numIndex index="0">Middle East (UAE) - me-central-1</numIndex>
-                            <numIndex index="1">me-central-1</numIndex>
+                            <label>Middle East (UAE) - me-central-1</label>
+                            <value>me-central-1</value>
                         </numIndex>
                         <numIndex index="25" type="array">
-                            <numIndex index="0">AWS GovCloud (US-East) - us-gov-east-1</numIndex>
-                            <numIndex index="1">us-gov-east-1</numIndex>
+                            <label>AWS GovCloud (US-East) - us-gov-east-1</label>
+                            <value>us-gov-east-1</value>
                         </numIndex>
                         <numIndex index="26" type="array">
-                            <numIndex index="0">AWS GovCloud (US-West) - us-gov-west-1</numIndex>
-                            <numIndex index="1">us-gov-west-1</numIndex>
+                            <label>AWS GovCloud (US-West) - us-gov-west-1</label>
+                            <value>us-gov-west-1</value>
                         </numIndex>
                     </items>
                     <size>1</size>
@@ -145,8 +145,7 @@
                     LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.customHost-description
                 </description>
                 <config>
-                    <type>input</type>
-                    <renderType>inputLink</renderType>
+                    <type>link</type>
                     <size>30</size>
                 </config>
             </customHost>
@@ -176,9 +175,8 @@
                     LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.secretKey
                 </label>
                 <config>
-                    <type>input</type>
+                    <type>password</type>
                     <size>30</size>
-                    <eval>password</eval>
                 </config>
             </secretKey>
             <publicBaseUrl>
@@ -206,9 +204,8 @@
                     LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.cacheHeaderDuration
                 </label>
                 <config>
-                    <type>input</type>
+                    <type>number</type>
                     <size>30</size>
-                    <eval>int</eval>
                     <range>
                         <lower>0</lower>
                     </range>
@@ -226,18 +223,18 @@
                     <maxitems>1</maxitems>
                     <items type="array">
                         <numIndex index="0" type="array">
-                            <numIndex index="0">
+                            <label>
                                 LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.protocol.auto
-                            </numIndex>
-                            <numIndex index="1">auto</numIndex>
+                            </label>
+                            <value>auto</value>
                         </numIndex>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">https://</numIndex>
-                            <numIndex index="1">https://</numIndex>
+                            <label>https://</label>
+                            <value>https://</value>
                         </numIndex>
                         <numIndex index="2" type="array">
-                            <numIndex index="0">http://</numIndex>
-                            <numIndex index="1">http://</numIndex>
+                            <label>http://</label>
+                            <value>http://</value>
                         </numIndex>
                     </items>
                 </config>
@@ -254,14 +251,14 @@
                     <maxitems>1</maxitems>
                     <items type="array">
                         <numIndex index="0" type="array">
-                            <numIndex index="0">
+                            <label>
                                 LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.signature.auto
-                            </numIndex>
-                            <numIndex index="1">0</numIndex>
+                            </label>
+                            <value>0</value>
                         </numIndex>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">v4</numIndex>
-                            <numIndex index="1">v4</numIndex>
+                            <label>v4</label>
+                            <value>v4</value>
                         </numIndex>
                     </items>
                 </config>
@@ -287,22 +284,22 @@
                     <maxitems>1</maxitems>
                     <items type="array">
                         <numIndex index="0" type="array">
-                            <numIndex index="0">
+                            <label>
                                 LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.fileContentHash.ignore
-                            </numIndex>
-                            <numIndex index="1">ignore</numIndex>
+                            </label>
+                            <value>ignore</value>
                         </numIndex>
                         <numIndex index="1" type="array">
-                            <numIndex index="0">
+                            <label>
                                 LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.fileContentHash.receive
-                            </numIndex>
-                            <numIndex index="1">receive</numIndex>
+                            </label>
+                            <value>receive</value>
                         </numIndex>
                         <numIndex index="2" type="array">
-                            <numIndex index="0">
+                            <label>
                                 LLL:EXT:aus_driver_amazon_s3/Resources/Private/Language/locallang_flexform.xlf:driverConfiguration.fileContentHash.force
-                            </numIndex>
-                            <numIndex index="1">force</numIndex>
+                            </label>
+                            <value>force</value>
                         </numIndex>
                     </items>
                 </config>


### PR DESCRIPTION
## Problem
Several TCA deprecations in the FlexForm definition trigger `E_USER_DEPRECATED`  errors in TYPO3 v12+. Example deprecation message: 
> /var/www/html/vendor/typo3/cms-core/Classes/Configuration/FlexForm/FlexFormTools.php:642
FlexFormTools did an on-the-fly migration of a flex form data structure. This is deprecated and will be removed. Merge the following changes into the flex form definition "cacheHeaderDuration":
The TCA field 'cacheHeaderDuration' in table 'dummyTable'" defines eval="int". The field has therefore been migrated to the TCA type 'number'. This includes corresponding migration of the "eval" list, as well as obsolete field configurations, such as "max". Please adjust your TCA accordingly.

## Changes
1. Migrate `cacheHeaderDuration` from `type=input` + `eval=int` to `type=number`
2. Migrate `secretKey` from `eval=password` to `type=password`
3. Migrate `customHost` from `type=input` + `renderType=inputLink` to `type=link`
4. Migrate select `items` from indexed array keys to associative `label`/`value` keys

## References
1. https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97193-NewTCATypeNumber.html
2. https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97104-NewTCATypePassword.html
3. https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97159-NewTCATypeLink.html
4. https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Deprecation-99739-IndexedArrayKeysForTCAItems.html