### PR TITLE
[TASK] Remove PHP 7.x handling

### DIFF
--- a/Classes/Service/CompatibilityService.php
+++ b/Classes/Service/CompatibilityService.php
@@ -18,7 +18,6 @@ namespace AUS\AusDriverAmazonS3\Service;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Core\SingletonInterface;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * This class is used to place functions which are more complex because keeping compatibility to older TYPO3 versions.
@@ -57,10 +56,6 @@ class CompatibilityService implements SingletonInterface
      */
     public function isFirstPartOfStr($str, $partStr): bool
     {
-        if (PHP_MAJOR_VERSION >= 8) {
-            return str_starts_with($str, $partStr);
-        } else {
-            return GeneralUtility::isFirstPartOfStr($str, $partStr);
-        }
+        return str_starts_with($str, $partStr);
     }
 }


### PR DESCRIPTION
Drops the PHP 7 fallback in isFirstPartOfStr(), now always using str_starts_with().