### PR TITLE
[BUGFIX] Remove deprecated $GLOBALS['TSFE'] test scaffolding

### DIFF
--- a/Tests/Unit/Driver/AmazonS3DriverTest.php
+++ b/Tests/Unit/Driver/AmazonS3DriverTest.php
@@ -69,7 +69,6 @@ class AmazonS3DriverTest extends TestCase
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][AmazonS3Driver::EXTENSION_KEY] = [];
         $GLOBALS['TYPO3_CONF_VARS']['LOG'] = [];
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['FileInfo']['fileExtensionToMimeType']['youtube'] = 'video/youtube';
-        $GLOBALS['TSFE'] = new \stdClass();
 
         Environment::initialize(
             $this->prophesize(ApplicationContext::class)->reveal(),
@@ -105,7 +104,7 @@ class AmazonS3DriverTest extends TestCase
 
     public function tearDown(): void
     {
-        unset($GLOBALS['TYPO3_REQUEST'], $GLOBALS['TSFE']);
+        unset($GLOBALS['TYPO3_REQUEST']);
         parent::tearDown();
     }
 


### PR DESCRIPTION
$GLOBALS['TSFE'] direct access is deprecated per
Deprecation-105230-TypoScriptFrontendControllerAndGLOBALSTSFE for TYPO3 13.4. Nothing in Classes/ reads this global; it was only ever dead bootstrap left over from 9578112 (PHP 8.0 / TYPO3 11.5 compat).