### PR TITLE
[FEATURE] Upgrade tests for PHP 8.4 & TYPO3v13 and fix deprecations in test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        php: ['8.1', '8.2']
+        php: ['8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerValidate
 
       - name: GrumPHP
-        run: .Build/vendor/phpro/grumphp/bin/grumphp run
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s grumphp
 
       - name: Lint PHP
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -59,12 +59,13 @@ Options:
             - postgres: use postgres
             - sqlite: use sqlite
 
-    -p <7.2|7.3|7.4|8.0>
+    -p <7.2|7.3|7.4|8.0|8.4>
         Specifies the PHP minor version to be used
             - 7.2: use PHP 7.2
             - 7.3: use PHP 7.3
             - 7.4: use PHP 7.4
             - 8.0: use PHP 8.0
+            - 8.4: use PHP 8.4
 
     -e "<phpunit options>"
         Only with -s functional|unit
@@ -269,10 +270,10 @@ case ${TEST_SUITE} in
         docker compose down
         ;;
     update)
-        # pull typo3/core-testing-*:latest versions of those ones that exist locally
-        docker images typo3/core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} docker pull {}
-        # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
-        docker images typo3/core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} docker rmi {}
+        # pull ghcr.io/typo3/core-testing-php-*:latest versions of those ones that exist locally
+        docker images ghcr.io/typo3/core-testing-php-*:latest --format "{{.Repository}}:latest" | xargs -I {} docker pull {}
+        # remove "dangling" ghcr.io/typo3/core-testing-php-* images (those tagged as <none>)
+        docker images ghcr.io/typo3/core-testing-php-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} docker rmi {}
         ;;
     *)
         echo "Invalid -s option argument ${TEST_SUITE}" >&2

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -47,6 +47,7 @@ Options:
             - composerInstallMax: "composer update", with no platform.php config.
             - composerInstallMin: "composer update --prefer-lowest", with platform.php set to PHP version x.x.0.
             - composerValidate: "composer validate"
+            - grumphp: "GrumPHP run"
             - lint: PHP linting
             - unit (default): PHP unit tests
             - functional: functional tests
@@ -255,6 +256,12 @@ case ${TEST_SUITE} in
                 echo "${HELP}" >&2
                 exit 1
         esac
+        docker compose down
+        ;;
+    grumphp)
+        setUpDockerComposeDotEnv
+        docker compose run grumphp
+        SUITE_EXIT_CODE=$?
         docker compose down
         ;;
     lint)

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -272,6 +272,24 @@ services:
         fi
       "
 
+  grumphp:
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+      - ${HOST_HOME}:${HOST_HOME}
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/group:/etc/group:ro
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        .Build/vendor/phpro/grumphp/bin/grumphp run;
+      "
+
   lint:
     image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ../../.Build/minio-data:/minio-data
 
   composer_install:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -45,7 +45,7 @@ services:
         composer install --no-progress --no-interaction;
       "
   composer_install_max:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -73,7 +73,7 @@ services:
       '
 
   composer_install_min:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -101,7 +101,7 @@ services:
       '
 
   composer_validate:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -118,7 +118,7 @@ services:
       "
 
   functional_mariadb10:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     links:
       - mariadb10
@@ -157,7 +157,7 @@ services:
       "
 
   functional_mssql2019latest:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     links:
       - mssql2019latest
@@ -200,7 +200,7 @@ services:
       "
 
   functional_postgres10:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     links:
       - postgres10
@@ -240,7 +240,7 @@ services:
       "
 
   functional_sqlite:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     links:
       - minio
@@ -273,7 +273,7 @@ services:
       "
 
   lint:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -290,7 +290,7 @@ services:
       "
 
   unit:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -186,7 +186,7 @@ class AmazonS3Driver extends AbstractHierarchicalFilesystemDriver implements Str
      * @param array $configuration
      * @param S3Client $s3Client
      */
-    public function __construct(array $configuration = [], $s3Client = null, EventDispatcherInterface $eventDispatcher = null)
+    public function __construct(array $configuration = [], $s3Client = null, ?EventDispatcherInterface $eventDispatcher = null)
     {
         parent::__construct($configuration);
         $this->eventDispatcher = $eventDispatcher ?? GeneralUtility::makeInstance(EventDispatcherInterface::class);

--- a/Classes/S3Adapter/AbstractS3Adapter.php
+++ b/Classes/S3Adapter/AbstractS3Adapter.php
@@ -32,7 +32,7 @@ class AbstractS3Adapter
      * AbstractS3Adapter constructor.
      * @param S3Client $s3Client
      */
-    public function __construct(S3Client $s3Client = null)
+    public function __construct(?S3Client $s3Client = null)
     {
         $this->s3Client = $s3Client;
     }

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@
 tests: unit-tests functional-tests
 
 functional-tests: .Build/bin/phpunit .Build/Web/typo3conf/ext/aus_driver_amazon_s3
-	 ./Build/Scripts/runTests.sh -p 8.2 -d sqlite -s functional\
+	 ./Build/Scripts/runTests.sh -p 8.4 -d sqlite -s functional\
 	    -e "--display-warnings --display-notices --display-errors"
 
 unit-tests: .Build/bin/phpunit .Build/Web/typo3conf/ext/aus_driver_amazon_s3
-	 ./Build/Scripts/runTests.sh -p 8.2 -d sqlite -s unit\
+	 ./Build/Scripts/runTests.sh -p 8.4 -d sqlite -s unit\
 	    -e "--display-warnings --display-notices --display-errors"
 
 .Build/bin/phpunit:

--- a/Tests/Unit/Driver/AmazonS3DriverTest.php
+++ b/Tests/Unit/Driver/AmazonS3DriverTest.php
@@ -18,6 +18,7 @@ use Aws\Api\DateTimeResult;
 use Aws\Result;
 use Aws\S3\S3Client;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ServerRequestInterface;
@@ -26,6 +27,7 @@ use TYPO3\CMS\Core\Core\ApplicationContext;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
+use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -98,6 +100,9 @@ class AmazonS3DriverTest extends TestCase
         ]);
         $this->s3Client = $this->prophesize(S3Client::class);
         $eventDispatcher = $this->prophesize(EventDispatcher::class);
+        $pageRenderer = $this->prophesize(PageRenderer::class);
+        $pageRenderer->addHeaderData(Argument::any())->willReturn(null);
+        GeneralUtility::setSingletonInstance(PageRenderer::class, $pageRenderer->reveal());
         $this->driver = new AmazonS3Driver($this->testConfiguration, $this->s3Client->reveal(), $eventDispatcher->reveal());
         $this->driver->setStorageUid(42);
         $this->driver->initialize();

--- a/Tests/Unit/Driver/AmazonS3DriverTest.php
+++ b/Tests/Unit/Driver/AmazonS3DriverTest.php
@@ -17,6 +17,7 @@ use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use Aws\Api\DateTimeResult;
 use Aws\Result;
 use Aws\S3\S3Client;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -114,9 +115,7 @@ class AmazonS3DriverTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testPublicUrlGetter()
     {
         $assertedMappings = [
@@ -131,25 +130,19 @@ class AmazonS3DriverTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testDefaultFolderGetter()
     {
         $this->assertEquals('/', $this->driver->getDefaultFolder());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testRootLevelFolderGetter()
     {
         $this->assertEquals('/', $this->driver->getRootLevelFolder());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testGetFileInfoByIdentifier()
     {
         $fileIdentifier = 'foo/bar/test.file';
@@ -182,9 +175,7 @@ class AmazonS3DriverTest extends TestCase
         $this->assertEquals($this->driver->getStorageUid(), $info['storage']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testGetFileInfoByIdentifierWithLimitedProperties()
     {
         $fileIdentifier = 'foo/bar/test.file';
@@ -206,9 +197,7 @@ class AmazonS3DriverTest extends TestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testGetFileInfoByIdentifierWithPseudoMimeType()
     {
         $fileIdentifier = 'foo/bar/test.youtube';

--- a/Tests/Unit/Index/ExtractorTest.php
+++ b/Tests/Unit/Index/ExtractorTest.php
@@ -15,6 +15,7 @@ namespace AUS\AusDriverAmazonS3\Tests\Unit\Index;
 
 use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use AUS\AusDriverAmazonS3\Index\Extractor;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use TYPO3\CMS\Core\Resource\File;
@@ -44,9 +45,7 @@ class ExtractorTest extends TestCase
         $this->extractor = new Extractor();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanProcessImageFileType()
     {
         $storage = $this->prophesize(ResourceStorage::class);
@@ -59,9 +58,7 @@ class ExtractorTest extends TestCase
         $this->assertEquals(true, $this->extractor->canProcess($file->reveal()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanNotProcessOtherDriverType()
     {
         $storage = $this->prophesize(ResourceStorage::class);
@@ -74,9 +71,7 @@ class ExtractorTest extends TestCase
         $this->assertEquals(false, $this->extractor->canProcess($file->reveal()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanNotProcessUnknownFileType()
     {
         $storage = $this->prophesize(ResourceStorage::class);
@@ -89,9 +84,7 @@ class ExtractorTest extends TestCase
         $this->assertEquals(false, $this->extractor->canProcess($file->reveal()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanNotProcessApplicationFileType()
     {
         $storage = $this->prophesize(ResourceStorage::class);
@@ -104,9 +97,7 @@ class ExtractorTest extends TestCase
         $this->assertEquals(false, $this->extractor->canProcess($file->reveal()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanNotProcessVideoFileType()
     {
         $storage = $this->prophesize(ResourceStorage::class);
@@ -119,9 +110,7 @@ class ExtractorTest extends TestCase
         $this->assertEquals(false, $this->extractor->canProcess($file->reveal()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanNotProcessAudioFileType()
     {
         $storage = $this->prophesize(ResourceStorage::class);
@@ -134,9 +123,7 @@ class ExtractorTest extends TestCase
         $this->assertEquals(false, $this->extractor->canProcess($file->reveal()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCanNotProcessTextFileType()
     {
         $storage = $this->prophesize(ResourceStorage::class);
@@ -149,9 +136,7 @@ class ExtractorTest extends TestCase
         $this->assertEquals(false, $this->extractor->canProcess($file->reveal()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testExtractMetaDataIfRequired()
     {
         $file = $this->prophesize(File::class);
@@ -166,9 +151,7 @@ class ExtractorTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testExtractNoMetaDataIfNotRequired()
     {
         $file = $this->prophesize(File::class);

--- a/Tests/Unit/S3Adapter/MetaInfoDownloadAdapterTest.php
+++ b/Tests/Unit/S3Adapter/MetaInfoDownloadAdapterTest.php
@@ -16,6 +16,7 @@ namespace AUS\AusDriverAmazonS3\Tests\Unit\S3Adapter;
 use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use AUS\AusDriverAmazonS3\S3Adapter\MetaInfoDownloadAdapter;
 use Aws\Api\DateTimeResult;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -55,9 +56,7 @@ class MetaInfoDownloadAdapterTest extends TestCase
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][FileInfo::class]['mimeTypeGuessers'][MimeTypeCompatibilityTypeGuesser::class] = MimeTypeCompatibilityTypeGuesser::class . '->guessMimeType';
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getMetaInfoFromResponseTest()
     {
         // prepare test data
@@ -95,9 +94,7 @@ class MetaInfoDownloadAdapterTest extends TestCase
         $this->assertEquals(42, $metaInfo['storage']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getMetaInfoFromResponseWithPseudoMimeTypeTest()
     {
         // prepare test data

--- a/Tests/Unit/S3Adapter/MultipartUploaderAdapterTest.php
+++ b/Tests/Unit/S3Adapter/MultipartUploaderAdapterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AUS\AusDriverAmazonS3\Tests\Unit\S3Adapter;
 
 use AUS\AusDriverAmazonS3\S3Adapter\MultipartUploaderAdapter;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class MultipartUploaderAdapterTest extends TestCase
@@ -17,9 +18,7 @@ class MultipartUploaderAdapterTest extends TestCase
         $this->multipartUploaderAdapter = new MultipartUploaderAdapter();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function detectContentTypeTest()
     {
         $fixtures = dirname(__FILE__) . '/../Fixtures/MultipartUploaderAdapter/';

--- a/Tests/Unit/Service/MetaDataUpdateServiceTest.php
+++ b/Tests/Unit/Service/MetaDataUpdateServiceTest.php
@@ -16,6 +16,7 @@ namespace AUS\AusDriverAmazonS3\Tests\Unit\Service;
 use AUS\AusDriverAmazonS3\Driver\AmazonS3Driver;
 use AUS\AusDriverAmazonS3\Index\Extractor;
 use AUS\AusDriverAmazonS3\Service\MetaDataUpdateService;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -32,9 +33,7 @@ class MetaDataUpdateServiceTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testRecordUpdatedOrCreatedDoNotHandleUnknownFileType()
     {
         $file = $this->prophesize(File::class)->reveal();
@@ -49,9 +48,7 @@ class MetaDataUpdateServiceTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testRecordUpdatedOrCreatedDoNotHandleApplicationFileType()
     {
         $file = $this->prophesize(File::class)->reveal();

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     ],
     "test": [
       "@setupTest",
-      "./Build/Scripts/runTests.sh -p '8.2' -s composerInstall && ./Build/Scripts/runTests.sh -p '8.2' -s composerValidate && ./Build/Scripts/runTests.sh -p '8.2' -s unit && ./Build/Scripts/runTests.sh -p '8.2' -s lint"
+      "./Build/Scripts/runTests.sh -p '8.4' -s composerInstall && ./Build/Scripts/runTests.sh -p '8.4' -s composerValidate && ./Build/Scripts/runTests.sh -p '8.4' -s unit && ./Build/Scripts/runTests.sh -p '8.4' -s lint"
     ]
   },
   "extra": {


### PR DESCRIPTION
Update tests to work with php8.4
- Docker image path typo3/core-testing-php* replaced with ghcr.io/typo3/core-testing-php-* because the first one has only support until 8.3.
- Registered a mocked PageRenderer singleton in the test setup. 

Fixed deps after running test:
     - Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead
     - Metadata found in doc-comment for method [Class]::method (). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12
     
Test tests:
´´´bash
make tests
´´´